### PR TITLE
0.0.4 Upgrade version of mincer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mincer-jsx",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "JSX engine for Mincer",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
     "mincer": "~1.2"
   },
   "dependencies": {
-    "react-tools": "~0.10.0"
+    "react-tools": "~0.12"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/example.js.jsx
+++ b/test/fixtures/example.js.jsx
@@ -1,2 +1,9 @@
-/** @jsx React.DOM */
-React.renderComponent(<div>Hello, world!</div>, document.body);
+var views = {
+  HelloWorld: React.createClass({
+    render: function() {
+      return <div>Hello, world!</div>;
+    }
+  })
+}
+
+React.renderComponent(<views.HelloWorld />, document.body);

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ env.appendPath(__dirname + '/fixtures');
 
 var compiledAsset = env.findAsset('example').toString();
 
-if (compiledAsset.indexOf('React.DOM.div(') > 0) {
+if (compiledAsset.indexOf('React.createElement("div"') > 0) {
   console.log('OK');
 } else {
   console.error('Failed to compile JSX');


### PR DESCRIPTION
NPM complained when I installed with newer version of Mincer. However it works fine.

Also would probably be a good idea to mention in the README that the `/** @jsx React.DOM */` at head of file is **not optional** as that tripped me up a bit. Would be awesome if it could be made optional.
