### PR TITLE
Upgrade version of mincer to 1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "mincer-jsx",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "JSX engine for Mincer",
   "main": "index.js",
   "scripts": {
     "test": "make test"
   },
   "devDependencies": {
-    "mincer": "~1.2"
+    "mincer": "~1.3"
   },
   "peerDependencies": {
-    "mincer": "~1.2"
+    "mincer": "~1.3"
   },
   "dependencies": {
     "react-tools": "~0.13"


### PR DESCRIPTION
Mincer 1.3 has just been released, which technically the minor version bump is more because of the potential `postcss` dependency upstream without much API change that breaks things.

I have also bumped the package version to 0.0.8 to reflect the change. Please kindly review. Thanks!
