### PR TITLE
Removed mincer dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-test:
-	@node test/test.js
-
-.PHONY: test

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var prop = require('mincer/lib/mincer/common').prop;
-
 // Second param is not mandatory, used only to force specific
 // module version when nested dependencies cause conflict.
 module.exports = function addJsxEngine(Mincer, jsx) {
@@ -14,10 +12,11 @@ module.exports = function addJsxEngine(Mincer, jsx) {
   require('util').inherits(JsxEngine, Mincer.Template);
 
   JsxEngine.prototype.evaluate = function evaluate(context, locals) {
-     return jsx.transform(this.data);
+     this.data = jsx.transform(this.data);
+     return;
   };
 
   Mincer.registerEngine('.jsx', Mincer.JsxEngine);
 
-  prop(Mincer.JsxEngine, 'defaultMimeType', 'application/javascript');
+  Object.defineProperty(Mincer.JsxEngine, 'defaultMimeType', {value: 'application/javascript'});
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var prop = require('mincer/lib/mincer/common').prop;
-
 // Second param is not mandatory, used only to force specific
 // module version when nested dependencies cause conflict.
 module.exports = function addJsxEngine(Mincer, jsx) {
@@ -14,10 +12,11 @@ module.exports = function addJsxEngine(Mincer, jsx) {
   require('util').inherits(JsxEngine, Mincer.Template);
 
   JsxEngine.prototype.evaluate = function evaluate(context, locals) {
-     return jsx.transform(this.data);
+    this.data = jsx.transform(this.data);
+    return;
   };
 
   Mincer.registerEngine('.jsx', Mincer.JsxEngine);
 
-  prop(Mincer.JsxEngine, 'defaultMimeType', 'application/javascript');
+  Object.defineProperty(Mincer.JsxEngine, 'defaultMimeType', {value: 'application/javascript'});
 };

--- a/package.json
+++ b/package.json
@@ -4,20 +4,15 @@
   "description": "JSX engine for Mincer",
   "main": "index.js",
   "scripts": {
-    "test": "make test"
-  },
-  "devDependencies": {
-    "mincer": "~1.2"
-  },
-  "peerDependencies": {
-    "mincer": "~1.2"
+    "test": "node test/test.js"
   },
   "dependencies": {
+    "mincer": "~1.3",
     "react-tools": "~0.13"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/frantic/mincer-jsx.git"
+    "url": "git://github.com/aug-riedinger/mincer-jsx.git"
   },
   "keywords": [
     "mincer",
@@ -28,10 +23,13 @@
     "react",
     "compile"
   ],
-  "author": "Alex Kotliarskyi",
+  "authors": [
+    "Alex Kotliarskyi",
+    "Augustin Riedinger"
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/frantic/mincer-jsx/issues"
+    "url": "https://github.com/aug-riedinger/mincer-jsx/issues"
   },
-  "homepage": "https://github.com/frantic/mincer-jsx"
+  "homepage": "https://github.com/aug-riedinger/mincer-jsx"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "node test/test.js"
   },
   "dependencies": {
-    "mincer": "~1.3",
     "react-tools": "~0.13"
   },
   "repository": {


### PR DESCRIPTION
Hello @frantic 

I needed to use `mincer-jsx` for the [connect-asset](https://github.com/adunkman/connect-assets/pull/330) project.

I removed the mincer dependency, simply using methods from the `mincer` object as a parameter instead. Indeed, it was not working since I need to use both v 1.3 and 1.2.

Let me know if you'd like to merge that.

Best
